### PR TITLE
Add multi-region support, marginal improvement to cost of execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Ensure you have a source and target bucket. They do not need to reside in the sa
 
 On the source bucket, add a tag named "TargetBucket" and give it a value of the name of the target bucket.
 
+You can specify multiple buckets delimited by semicolons, e.g. `StagingBucket;DisasterRecoveryBucket;Etc`.
+
 ### Lambda Function
 
 1. Create a new Lambda function. 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ On the source bucket, add a tag named "TargetBucket" and give it a value of the 
 
 You can specify multiple buckets delimited by semicolons, e.g. `StagingBucket;DisasterRecoveryBucket;Etc`.
 
+If the bucket is in another region, you will need to specify the region delimited with an `@` token,
+e.g. `StagingBucket@eu-central-1;DisasterRecoveryBucket@eu-west-1;BucketInSameRegion;Etc`.
+
+We don't use the API to retrieve the region of the bucket to avoid burning API usages
+($0.004 x 1000 requests under heavy traffic can mount up faster than you'd imagine).
+
+If you don't specify the region for a bucket that is outside the function's region,
+you will see an error that looks like this:
+
+> [PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
+
 ### Lambda Function
 
 1. Create a new Lambda function. 

--- a/index.js
+++ b/index.js
@@ -109,13 +109,10 @@ function checkForCompletion(context, error) {
         return;
     }
     
-    if (seenErrors.length > 0)
-    {
+    if (seenErrors.length > 0) {
         context.fail("Failed to upload " + seenErrors.length  + " files of " + itemsToUpload
             + ". Check the logs for more information.");
-    }
-    else
-    {
+    } else {
         context.succeed("Successfully uploaded " + completedItems + " files.");
     }
 }

--- a/index.js
+++ b/index.js
@@ -63,7 +63,19 @@ function getTargetBucket(bucketName, callback) {
             var tag = tags[i];
             if (tag.Key == 'TargetBucket') {
                 console.log("Tag 'TargetBucket' found with value '" + tag.Value + "'");
-                callback(tag.Value);
+
+                var buckets = tag.Value.split(";");
+
+                for (var j = 0; j < buckets.length ; j++)
+                {
+                    var bucket = buckets[i].trim();
+
+                    if (bucket.length > 0)
+                    {
+                        callback(bucket);
+                    }
+                }
+
                 return;
             }
         }


### PR DESCRIPTION
Thanks for the great script guys. I had some quick modifications I had to make to make it suitable for my needs that you might like:
1. Added ability for user to specify multiple destination buckets with the `MyBucket;MyOtherBucket` syntax.
2. Fixed issue where it was not possible to copy an object to another region by allowing the user to specify which region to copy to using the `MyBucket@eu-central-1` syntax.
3. The context is now marked as failed or succeeded once all files have been processed. Apparently this helps AWS to definitely know when to close the session, and it does seem to reduce the billed execution time by 100-200ms or so which might be significant in heavy usage environments (like mine).

The syntax in points #1 and #2 is also documented in README.md.
